### PR TITLE
Use cli to install browsers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,36 @@
 {
   "name": "@recordreplay/playwright-config",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@recordreplay/playwright-config",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "0.2.0",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@recordreplay/recordings-cli": "file:../recordings-cli"
+      },
       "devDependencies": {
         "@types/node": "^17.0.21"
       }
+    },
+    "../recordings-cli": {
+      "name": "@recordreplay/recordings-cli",
+      "version": "0.10.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "commander": "^7.2.0",
+        "ws": "^7.5.0"
+      },
+      "bin": {
+        "replay-recordings": "bin/replay-recordings"
+      }
+    },
+    "node_modules/@recordreplay/recordings-cli": {
+      "resolved": "../recordings-cli",
+      "link": true
     },
     "node_modules/@types/node": {
       "version": "17.0.21",
@@ -20,6 +40,13 @@
     }
   },
   "dependencies": {
+    "@recordreplay/recordings-cli": {
+      "version": "file:../recordings-cli",
+      "requires": {
+        "commander": "^7.2.0",
+        "ws": "^7.5.0"
+      }
+    },
     "@types/node": {
       "version": "17.0.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@recordreplay/playwright-config",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Configuration utilities for using the Replay browsers with playwright",
   "main": "index.js",
   "scripts": {
+    "install": "node -e 'process.exit(require(\"fs\").existsSync(\"./install.js\") ? 1 : 0)' || node ./install.js",
     "build": "tsc && cp package.json dist/",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -11,5 +12,8 @@
   "license": "BSD-3-Clause",
   "devDependencies": {
     "@types/node": "^17.0.21"
+  },
+  "dependencies": {
+    "@recordreplay/recordings-cli": "^0.10.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,41 +1,10 @@
-import path from "path";
-
-type BrowserName = 'chromium' | 'firefox' | 'webkit';
-
-const EXECUTABLE_PATHS = {
-  "darwin:firefox": ["firefox", "Nightly.app", "Contents", "MacOS", "firefox"],
-  "linux:chromium": ["chrome-linux", "chrome"],
-  "linux:firefox": ["firefox", "firefox"],
-} as const;
-
-function getPlatformKey(browserName: BrowserName): keyof typeof EXECUTABLE_PATHS | undefined {
-  const key = `${process.platform}:${browserName}`;
-  switch (key) {
-    case "darwin:firefox":
-    case "linux:firefox":
-    case "linux:chromium":
-      return key;
-  }
-
-  return undefined;
-}
-
-export function getExecutablePath(browserName: BrowserName) {
-  // Override with replay specific browsers.
-  const replayDir =
-    process.env.RECORD_REPLAY_DIRECTORY ||
-    path.join(process.env.HOME!, ".replay");
-
-  const key = getPlatformKey(browserName);
-  if (!key) {
-    return;
-  }
-
-  return path.join(replayDir, "playwright", ...EXECUTABLE_PATHS[key]);
-}
+import {
+  getPlaywrightBrowserPath,
+  BrowserName,
+} from "@recordreplay/recordings-cli";
 
 function getDeviceConfig(browserName: BrowserName) {
-  const executablePath = getExecutablePath(browserName);
+  const executablePath = getPlaywrightBrowserPath(browserName);
   if (!executablePath) {
     console.warn(`${browserName} is not supported on this platform`);
   }
@@ -44,11 +13,15 @@ function getDeviceConfig(browserName: BrowserName) {
     launchOptions: {
       executablePath,
       env: {
-        RECORD_ALL_CONTENT: 1
+        RECORD_ALL_CONTENT: 1,
       },
     },
     defaultBrowserType: browserName,
   };
+}
+
+export function getExecutablePath(browserName: BrowserName) {
+  return getPlaywrightBrowserPath(browserName);
 }
 
 export const devices = {

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,0 +1,3 @@
+import { ensurePlaywrightBrowsersInstalled } from "@recordreplay/recordings-cli";
+
+(async () => await ensurePlaywrightBrowsersInstalled("all"))();

--- a/src/recordreplay__recordings-cli.d.ts
+++ b/src/recordreplay__recordings-cli.d.ts
@@ -1,0 +1,32 @@
+declare module '@recordreplay/recordings-cli' {
+  /**
+   * Supported replay browsers
+   */
+  export type BrowserName = "chromium" | "firefox";
+
+  /**
+   * Returns the path to playwright for the current platform
+   * @param browserName BrowserName
+   */
+  export function getPlaywrightBrowserPath(browserName: BrowserName): string | null;
+
+  /**
+   * Returns the path to puppeteer for the current platform
+   * @param browserName BrowserName
+   */
+  export function getPuppeteerBrowserPath(browserName: BrowserName): string | null;
+
+  /**
+   * Installs the Replay-enabled playwright browsers for the current platform is
+   * not already installed
+   * @param browserName BrowserName | "all"
+   */
+  export function ensurePlaywrightBrowsersInstalled(browserName: BrowserName | "all"): Promise<void>;
+
+  /**
+   * Installs the Replay-enabled puppeteer browsers for the current platform is
+   * not already installed
+   * @param browserName BrowserName | "all"
+   */
+  export function ensurePuppeteerBrowsersInstalled(browserName: BrowserName | "all"): Promise<void>;
+}


### PR DESCRIPTION
* Moves the path determination to the CLI package
* Adds an install script to install the playwright browsers when this package is installed
  * The little trick in the `"scripts"` block avoids trying to run the script when running `npm install` in this module by checking for `install.js` which only exists in the built version deployed to npm
* Adds a typescript declaration file for the relevant CLI methods which we can sunset after migrating the CLI to typescript